### PR TITLE
fix: add BusOnRequest to Mode of Transport enum

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -26,6 +26,7 @@ pub enum Mot {
     PlusBus,
     Footpath,
     RapidTransit,
+    BusOnRequest,
 }
 
 #[derive(Serialize, Deserialize, JsonSchema, Clone, Debug)]


### PR DESCRIPTION
I added the enum "BusOnRequest" because the VVO API now delivers it and this produces an error.
It can be reproduced for the station "Amselgrund" "33000472".

It would be great if it could be merged ASAP and released in a new version, otherwise my application cannot be used.

Best regards, RedSpark